### PR TITLE
Fixed References, Commented, Code Coverage.

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -1,0 +1,15 @@
+
+github.com/CrowBits/go-bip39/bip39.go	 addChecksum				 100.00% (11/11)
+github.com/CrowBits/go-bip39/bip39.go	 IsMnemonicValid			 100.00% (8/8)
+github.com/CrowBits/go-bip39/bip39.go	 NewEntropy				 100.00% (6/6)
+github.com/CrowBits/go-bip39/bip39.go	 contains				 100.00% (4/4)
+github.com/CrowBits/go-bip39/bip39.go	 NewSeedWithErrorChecking		 100.00% (4/4)
+github.com/CrowBits/go-bip39/bip39.go	 validateEntropyBitSize			 100.00% (3/3)
+github.com/CrowBits/go-bip39/bip39.go	 validateEntropyWithChecksumBitSize	 100.00% (3/3)
+github.com/CrowBits/go-bip39/bip39.go	 padByteSlice				 100.00% (2/2)
+github.com/CrowBits/go-bip39/wordlist.go init					 100.00% (2/2)
+github.com/CrowBits/go-bip39/bip39.go	 NewSeed				 100.00% (1/1)
+github.com/CrowBits/go-bip39/bip39.go	 NewMnemonic				 93.75% (15/16)
+github.com/CrowBits/go-bip39/bip39.go	 MnemonicToByteArray			 90.24% (37/41)
+github.com/CrowBits/go-bip39		 ----------------------------------	 95.05% (96/101)
+


### PR DESCRIPTION
1. References to code.google.com were removed.
1. Comments were added so that go vet and friends would stop complaining.
1. Additional tests were added to get code coverage up.
1. Current coverage was documented in coverage.txt.
1. There is an issue with the conversion of a mnemonic back into bytes, it doesnt work for test vectors
 * 0
 * 4
 * 8